### PR TITLE
Increase font-size of bookmark titles to 14px for readability

### DIFF
--- a/app/bookmarks/index.css
+++ b/app/bookmarks/index.css
@@ -4,7 +4,7 @@
 .repo-box .hdr { padding: 10px 10px 12px 20px; display: block; }
 
 .repo-box li { padding: 5px 20px 15px 20px; display: flex; font-weight: 100; position: relative; }
-.repo-box li a.btn { padding: 0; font-size: 12px; flex: 1; }
+.repo-box li a.btn { padding: 0; font-size: 14px; flex: 1; }
 
 .repo-box li .build-status .icon,
 .repo-box li i { width: 18px; min-width: 18px; font-size: 14px; margin: -1px 3px 0 0; }


### PR DESCRIPTION
12px

![screen shot 2017-04-25 at 15 25 08](https://cloud.githubusercontent.com/assets/5951798/25390620/fe1b62e6-29cb-11e7-9239-a29e8f283bcd.png)

14px

![screen shot 2017-04-25 at 15 21 15](https://cloud.githubusercontent.com/assets/5951798/25390621/fed0d14e-29cb-11e7-86b5-3d2ed64ef711.png)

